### PR TITLE
Add ability to submit spam to SFS database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.cache/

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The `IsSpamUsername`-rule has one optional paramter `frequency` (default 10) to 
 
 #### Adding to the Database
 
-You can report a spammer to the StopForumSpam database using `addToDatabase()`. This requires an API key (set `STOPFORUMSPAM_APIKEY` in your `.env`) and all three of: `ip`, `email`, and `username`. Evidence is optional.
+You can report a spammer to the StopForumSpam database using `addToDatabase()`. This requires an API key (set `STOPFORUMSPAM_APIKEY` in your `.env`) and all three of: `ip`, `email`, and `username`. Evidence is optional and should be the post content. Do not include your email or site URL in Evidence.
+
+See Adding to the Database for more information: https://www.stopforumspam.com/usage
 
 ```php
 \StopForumSpam::setIp('8.8.8.8')

--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 ## Laravel StopForumSpam
+
 [![Build Status](https://github.com/nickurt/laravel-stopforumspam/workflows/tests/badge.svg)](https://github.com/nickurt/laravel-stopforumspam/actions)
 [![Total Downloads](https://poser.pugx.org/nickurt/laravel-stopforumspam/d/total.svg)](https://packagist.org/packages/nickurt/laravel-plesk)
 [![Latest Stable Version](https://poser.pugx.org/nickurt/laravel-stopforumspam/v/stable.svg)](https://packagist.org/packages/nickurt/laravel-plesk)
 [![MIT Licensed](https://poser.pugx.org/nickurt/laravel-stopforumspam/license.svg)](LICENSE.md)
 
 ### Installation
+
 Install this package with composer:
+
 ```
 composer require nickurt/laravel-stopforumspam
 ```
+
 Copy the config files for the StopForumSpam-plugin
+
 ```
 php artisan vendor:publish --provider="nickurt\StopForumSpam\ServiceProvider" --tag="config"
 ```
+
 ### Examples
+
 #### Validation Rule - IsSpamEmail
+
 ```php
 // FormRequest ...
 
@@ -29,8 +37,11 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['email' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamEmail(20)]]);
 ```
+
 The `IsSpamEmail`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Validation Rule - IsSpamIp
+
 ```php
 // FormRequest ...
 
@@ -45,8 +56,11 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['ip' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamIp(20)]]);
 ```
+
 The `IsSpamIp`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Validation Rule - IsSpamUsername
+
 ```php
 // FormRequest ...
 
@@ -61,32 +75,72 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['username' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamUsername(20)]]);
 ```
+
 The `IsSpamUsername`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Manually Usage - IsSpamEmail
+
 ```php
 \StopForumSpam::setEmail('nickurt@users.noreply.github.com')->isSpamEmail();
 ```
+
 #### Manually Usage - IsSpamIp
+
 ```php
 \StopForumSpam::setIp('8.8.8.8')->isSpamIp();
 ```
+
 #### Manually Usage - IsSpamUsername
+
 ```php
 \StopForumSpam::setUsername('nickurt')->isSpamUsername();
 ```
+
+#### Adding to the Database
+
+You can report a spammer to the StopForumSpam database using `reportSpam()`. This requires an API key (set `STOPFORUMSPAM_APIKEY` in your `.env`) and all three of: `ip`, `email`, and `username`. Evidence is optional and should be the post content. Do not include your email or site URL in Evidence.
+
+See Adding to the Database for more information: https://www.stopforumspam.com/usage
+
+```php
+\StopForumSpam::setIp('8.8.8.8')
+    ->setEmail('spam@example.com')
+    ->setUsername('spammer')
+    ->reportSpam();
+
+// Optionally include evidence
+\StopForumSpam::setIp('8.8.8.8')
+    ->setEmail('spam@example.com')
+    ->setUsername('spammer')
+    ->setEvidence('Posted 50 identical spam messages.')
+    ->reportSpam();
+```
+
+Returns `true` on success. Throws a `MalformedIPException` if the IP is invalid, a `MalformedEmailException` if the email is invalid, or an `Exception` if the API key or any required field is missing.
+
 #### Events
+
 You can listen to the `IsSpamEmail`, `IsSpamIp` and `IsSpamUsername` events, e.g. if you want to log all the `IsSpam`-requests in your application
+
 ##### IsSpamEmail Event
+
 This event will be fired when the request-email is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamEmail`
+
 ##### IsSpamIp Event
+
 This event will be fired when the request-ip is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamIp`
+
 ##### IsSpamUsername Event
+
 This event will be fired when the request-username is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamUsername`
+
 ### Tests
+
 ```sh
 composer test
 ```
-- - - 
+
+---

--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 ## Laravel StopForumSpam
+
 [![Build Status](https://github.com/nickurt/laravel-stopforumspam/workflows/tests/badge.svg)](https://github.com/nickurt/laravel-stopforumspam/actions)
 [![Total Downloads](https://poser.pugx.org/nickurt/laravel-stopforumspam/d/total.svg)](https://packagist.org/packages/nickurt/laravel-plesk)
 [![Latest Stable Version](https://poser.pugx.org/nickurt/laravel-stopforumspam/v/stable.svg)](https://packagist.org/packages/nickurt/laravel-plesk)
 [![MIT Licensed](https://poser.pugx.org/nickurt/laravel-stopforumspam/license.svg)](LICENSE.md)
 
 ### Installation
+
 Install this package with composer:
+
 ```
 composer require nickurt/laravel-stopforumspam
 ```
+
 Copy the config files for the StopForumSpam-plugin
+
 ```
 php artisan vendor:publish --provider="nickurt\StopForumSpam\ServiceProvider" --tag="config"
 ```
+
 ### Examples
+
 #### Validation Rule - IsSpamEmail
+
 ```php
 // FormRequest ...
 
@@ -29,8 +37,11 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['email' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamEmail(20)]]);
 ```
+
 The `IsSpamEmail`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Validation Rule - IsSpamIp
+
 ```php
 // FormRequest ...
 
@@ -45,8 +56,11 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['ip' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamIp(20)]]);
 ```
+
 The `IsSpamIp`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Validation Rule - IsSpamUsername
+
 ```php
 // FormRequest ...
 
@@ -61,32 +75,70 @@ public function rules()
 
 $validator = validator()->make(request()->all(), ['username' => ['required', new \nickurt\StopForumSpam\Rules\IsSpamUsername(20)]]);
 ```
+
 The `IsSpamUsername`-rule has one optional paramter `frequency` (default 10) to validate the request.
+
 #### Manually Usage - IsSpamEmail
+
 ```php
 \StopForumSpam::setEmail('nickurt@users.noreply.github.com')->isSpamEmail();
 ```
+
 #### Manually Usage - IsSpamIp
+
 ```php
 \StopForumSpam::setIp('8.8.8.8')->isSpamIp();
 ```
+
 #### Manually Usage - IsSpamUsername
+
 ```php
 \StopForumSpam::setUsername('nickurt')->isSpamUsername();
 ```
+
+#### Adding to the Database
+
+You can report a spammer to the StopForumSpam database using `addToDatabase()`. This requires an API key (set `STOPFORUMSPAM_APIKEY` in your `.env`) and all three of: `ip`, `email`, and `username`. Evidence is optional.
+
+```php
+\StopForumSpam::setIp('8.8.8.8')
+    ->setEmail('spam@example.com')
+    ->setUsername('spammer')
+    ->addToDatabase();
+
+// Optionally include evidence
+\StopForumSpam::setIp('8.8.8.8')
+    ->setEmail('spam@example.com')
+    ->setUsername('spammer')
+    ->setEvidence('Posted 50 identical spam messages.')
+    ->addToDatabase();
+```
+
+Returns `true` on success. Throws a `MalformedIPException` if the IP is invalid, a `MalformedEmailException` if the email is invalid, or an `Exception` if the API key or any required field is missing.
+
 #### Events
+
 You can listen to the `IsSpamEmail`, `IsSpamIp` and `IsSpamUsername` events, e.g. if you want to log all the `IsSpam`-requests in your application
+
 ##### IsSpamEmail Event
+
 This event will be fired when the request-email is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamEmail`
+
 ##### IsSpamIp Event
+
 This event will be fired when the request-ip is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamIp`
+
 ##### IsSpamUsername Event
+
 This event will be fired when the request-username is above the frequency of sending spam
 `nickurt\StopForumSpam\Events\IsSpamUsername`
+
 ### Tests
+
 ```sh
 composer test
 ```
-- - - 
+
+---

--- a/config/stopforumspam.php
+++ b/config/stopforumspam.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    //
+    'api_key'   => env('STOPFORUMSPAM_APIKEY', ''),
 ];

--- a/src/Exception/MalformedEmailException.php
+++ b/src/Exception/MalformedEmailException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace nickurt\StopForumSpam\Exception;
+
+class MalformedEmailException extends \RuntimeException
+{
+}

--- a/src/Exception/MalformedIPException.php
+++ b/src/Exception/MalformedIPException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace nickurt\StopForumSpam\Exception;
+
+class MalformedIPException extends \RuntimeException
+{
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,10 +11,14 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function boot()
     {
-        $this->loadTranslationsFrom(__DIR__.'/../src/Resources/Lang', 'stopforumspam');
+        $this->loadTranslationsFrom(__DIR__.'/Resources/Lang', 'stopforumspam');
 
         $this->publishes([
-            __DIR__.'/../src/Resources/Lang' => resource_path('lang/vendor/stopforumspam'),
+            __DIR__.'/Resources/Lang' => resource_path('lang/vendor/stopforumspam'),
+        ], 'lang');
+
+        $this->publishes([
+            __DIR__.'/../config/stopforumspam.php' => config_path('stopforumspam.php'),
         ], 'config');
     }
 

--- a/src/StopForumSpam.php
+++ b/src/StopForumSpam.php
@@ -8,12 +8,20 @@ use Illuminate\Support\Str;
 use nickurt\StopForumSpam\Events\IsSpamEmail;
 use nickurt\StopForumSpam\Events\IsSpamIp;
 use nickurt\StopForumSpam\Events\IsSpamUsername;
+use nickurt\StopForumSpam\Exception\MalformedEmailException;
+use nickurt\StopForumSpam\Exception\MalformedIPException;
 use nickurt\StopForumSpam\Exception\MalformedURLException;
 
 class StopForumSpam
 {
     /** @var string */
     protected $apiUrl = 'https://api.stopforumspam.org/api';
+
+    /** @var string */
+    protected $reportSpamUrl = 'https://www.stopforumspam.com/add.php';
+
+    /** @var string */
+    protected $apiKey;
 
     /** @var string */
     protected $email;
@@ -26,6 +34,9 @@ class StopForumSpam
 
     /** @var string */
     protected $username;
+
+    /** @var string */
+    protected $evidence;
 
     /**
      * @return bool
@@ -91,6 +102,29 @@ class StopForumSpam
     }
 
     /**
+    * @return string
+    */
+    public function getReportSpamUrl(): string
+    {
+        return $this->reportSpamUrl;
+    }
+
+    /**
+    * @param string $reportSpamUrl
+    * @return $this
+    */
+    public function setReportSpamUrl(string $reportSpamUrl): static
+    {
+        if (filter_var($reportSpamUrl, FILTER_VALIDATE_URL) === false) {
+            throw new MalformedURLException();
+        }
+
+        $this->reportSpamUrl = $reportSpamUrl;
+
+        return $this;
+    }
+
+    /**
      * @param  string  $apiUrl
      * @return $this
      */
@@ -101,6 +135,25 @@ class StopForumSpam
         }
 
         $this->apiUrl = $apiUrl;
+
+        return $this;
+    }
+
+    /**
+    * @return string
+    */
+    public function getApiKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    /**
+    * @param string $apiKey
+    * @return $this
+    */
+    public function setApiKey(string $apiKey): static
+    {
+        $this->apiKey = $apiKey;
 
         return $this;
     }
@@ -216,5 +269,100 @@ class StopForumSpam
         $this->username = $username;
 
         return $this;
+    }
+
+    /**
+     * @return string
+    */
+    public function getEvidence(): ?string
+    {
+        return $this->evidence;
+    }
+
+    /**
+    * @param string $evidence
+    * @return $this
+    */
+    public function setEvidence(string $evidence): static
+    {
+        $this->evidence = $evidence;
+
+        return $this;
+    }
+
+    /**
+     * POST to the given URL and return the HTTP status code.
+     * Fields are UTF-8 encoded and urlencoded as required by the SFS API.
+     *
+     * @param string $url
+     * @param array  $fields
+     * @return int
+     * @throws \Exception
+     */
+    protected function getResponseCode(string $url, array $fields): int
+    {
+        $encodedFields = http_build_query($fields);
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ])->send('POST', $url, [
+                'body' => $encodedFields,
+            ]);
+        } catch (\Exception $e) {
+            throw new \Exception('StopForumSpam request failed: ' . $e->getMessage());
+        }
+
+        return $response->status();
+    }
+
+    /**
+     * Submit a spam report to Stop Forum Spam.
+     * Requires api_key, ip, email, and username. Evidence is optional.
+     *
+     * See "Adding to the Database": https://www.stopforumspam.com/usage
+     *
+     * @return bool
+     * @throws \Exception
+     * @throws MalformedEmailException
+     */
+    public function reportSpam(): bool
+    {
+        if (empty($this->getApiKey())) {
+            throw new Exception('StopForumSpam API key is required.');
+        }
+
+        if (empty($this->getIp())) {
+            throw new Exception('ip is required.');
+        }
+
+        if (filter_var($this->getIp(), FILTER_VALIDATE_IP) === false) {
+            throw new MalformedIPException();
+        }
+
+        if (empty($this->getEmail())) {
+            throw new Exception('email is required.');
+        }
+
+        if (filter_var($this->getEmail(), FILTER_VALIDATE_EMAIL) === false) {
+            throw new MalformedEmailException();
+        }
+
+        if (empty($this->getUsername())) {
+            throw new Exception('username is required.');
+        }
+
+        $fields = [
+            'api_key'  => $this->getApiKey(),
+            'ip_addr'  => $this->getIp(),
+            'email'    => $this->getEmail(),
+            'username' => mb_convert_encoding($this->getUsername(), 'UTF-8'),
+        ];
+
+        if (!empty($this->getEvidence())) {
+            $fields['evidence'] = mb_convert_encoding($this->getEvidence(), 'UTF-8');
+        }
+
+        return $this->getResponseCode($this->getReportSpamUrl(), $fields) === 200;
     }
 }

--- a/src/StopForumSpam.php
+++ b/src/StopForumSpam.php
@@ -8,12 +8,20 @@ use Illuminate\Support\Str;
 use nickurt\StopForumSpam\Events\IsSpamEmail;
 use nickurt\StopForumSpam\Events\IsSpamIp;
 use nickurt\StopForumSpam\Events\IsSpamUsername;
+use nickurt\StopForumSpam\Exception\MalformedEmailException;
+use nickurt\StopForumSpam\Exception\MalformedIPException;
 use nickurt\StopForumSpam\Exception\MalformedURLException;
 
 class StopForumSpam
 {
     /** @var string */
     protected $apiUrl = 'https://api.stopforumspam.org/api';
+
+    /** @var string */
+    protected $addToDatabaseUrl = 'https://www.stopforumspam.com/add.php';
+
+    /** @var string */
+    protected $apiKey;
 
     /** @var string */
     protected $email;
@@ -26,6 +34,9 @@ class StopForumSpam
 
     /** @var string */
     protected $username;
+
+    /** @var string */
+    protected $evidence;
 
     /**
      * @return bool
@@ -91,6 +102,29 @@ class StopForumSpam
     }
 
     /**
+    * @return string
+    */
+    public function getAddToDatabaseUrl(): string
+    {
+        return $this->addToDatabaseUrl;
+    }
+
+    /**
+    * @param string $addToDatabaseUrl
+    * @return $this
+    */
+    public function setAddToDatabaseUrl(string $addToDatabaseUrl): static
+    {
+        if (filter_var($addToDatabaseUrl, FILTER_VALIDATE_URL) === false) {
+            throw new MalformedURLException();
+        }
+
+        $this->addToDatabaseUrl = $addToDatabaseUrl;
+
+        return $this;
+    }
+
+    /**
      * @param  string  $apiUrl
      * @return $this
      */
@@ -101,6 +135,25 @@ class StopForumSpam
         }
 
         $this->apiUrl = $apiUrl;
+
+        return $this;
+    }
+
+    /**
+    * @return string
+    */
+    public function getApiKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    /**
+    * @param string $apiKey
+    * @return $this
+    */
+    public function setApiKey(string $apiKey): static
+    {
+        $this->apiKey = $apiKey;
 
         return $this;
     }
@@ -216,5 +269,103 @@ class StopForumSpam
         $this->username = $username;
 
         return $this;
+    }
+
+    /**
+     * @return string
+    */
+    public function getEvidence(): ?string
+    {
+        return $this->evidence;
+    }
+
+    /**
+    * @param string $evidence
+    * @return $this
+    */
+    public function setEvidence(string $evidence): static
+    {
+        $this->evidence = $evidence;
+
+        return $this;
+    }
+
+    /**
+     * POST to the given URL and return the HTTP status code.
+     * Fields are UTF-8 encoded and urlencoded as required by the SFS API.
+     *
+     * @param string $url
+     * @param array  $fields
+     * @return int
+     * @throws \Exception
+     */
+    protected function getResponseCode(string $url, array $fields): int
+    {
+        // Urlencode all values to satisfy the SFS requirement
+        $encodedFields = http_build_query(
+            array_map(fn($v) => urlencode((string) $v), $fields)
+        );
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ])->send('POST', $url, [
+                'body' => $encodedFields,
+            ]);
+        } catch (\Exception $e) {
+            throw new \Exception('StopForumSpam request failed: ' . $e->getMessage());
+        }
+
+        return $response->status();
+    }
+
+    /**
+     * Submit a spam report to Stop Forum Spam.
+     * Requires api_key, ip, email, and username. Evidence is optional.
+     *
+     * See "Adding to the Database": https://www.stopforumspam.com/usage
+     *
+     * @return bool
+     * @throws \Exception
+     * @throws MalformedEmailException
+     */
+    public function addToDatabase(): bool
+    {
+        if (empty($this->getApiKey())) {
+            throw new Exception('StopForumSpam API key is required.');
+        }
+
+        if (empty($this->getIp())) {
+            throw new Exception('ip is required.');
+        }
+
+        if (filter_var($this->getIp(), FILTER_VALIDATE_IP) === false) {
+            throw new MalformedIPException();
+        }
+
+        if (empty($this->getEmail())) {
+            throw new Exception('email is required.');
+        }
+
+        if (filter_var($this->getEmail(), FILTER_VALIDATE_EMAIL) === false) {
+            throw new MalformedEmailException();
+        }
+
+        if (empty($this->getUsername())) {
+            throw new Exception('username is required.');
+        }
+
+        $fields = [
+            'api_key'  => $this->getApiKey(),
+            'ip_addr'  => $this->getIp(),
+            'email'    => $this->getEmail(),
+            'username' => mb_convert_encoding($this->getUsername(), 'UTF-8'),
+        ];
+
+        if (!empty($this->getEvidence())) {
+            $fields['evidence'] = mb_convert_encoding($this->getEvidence(), 'UTF-8');
+        }
+
+        return $this->getResponseCode($this->getAddToDatabaseUrl(), $fields) === 200;
     }
 }

--- a/tests/StopForumSpamTest.php
+++ b/tests/StopForumSpamTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Http;
 use nickurt\StopForumSpam\Events\IsSpamEmail;
 use nickurt\StopForumSpam\Events\IsSpamIp;
 use nickurt\StopForumSpam\Events\IsSpamUsername;
+use nickurt\StopForumSpam\Exception\MalformedEmailException;
+use nickurt\StopForumSpam\Exception\MalformedIPException;
 use nickurt\StopForumSpam\Exception\MalformedURLException;
 use nickurt\StopForumSpam\Facade as StopForumSpam;
 
@@ -180,5 +182,106 @@ class StopForumSpamTest extends TestCase
         $this->expectException(MalformedURLException::class);
 
         $this->stopForumSpam->setApiUrl('malformed_url');
+    }
+
+    public function test_it_can_report_spam()
+    {
+        Http::fake(['https://www.stopforumspam.com/add.php' => Http::response('', 200)]);
+
+        $result = $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->reportSpam();
+
+        $this->assertTrue($result);
+    }
+
+    public function test_it_can_report_spam_with_evidence()
+    {
+        Http::fake(['https://www.stopforumspam.com/add.php' => Http::response('', 200)]);
+
+        $result = $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->setEvidence('Posted 50 identical spam messages.')
+            ->reportSpam();
+
+        $this->assertTrue($result);
+    }
+
+    public function test_it_will_throw_exception_when_report_spam_without_api_key()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('StopForumSpam API key is required.');
+
+        $this->stopForumSpam
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->reportSpam();
+    }
+
+    public function test_it_will_throw_exception_when_report_spam_without_ip()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('ip is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->reportSpam();
+    }
+
+    public function test_it_will_throw_malformed_ip_exception_when_report_spam_with_invalid_ip()
+    {
+        $this->expectException(MalformedIPException::class);
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('not-an-ip')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->reportSpam();
+    }
+
+    public function test_it_will_throw_exception_when_report_spam_without_email()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('email is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setUsername('spammer')
+            ->reportSpam();
+    }
+
+    public function test_it_will_throw_malformed_email_exception_when_report_spam_with_invalid_email()
+    {
+        $this->expectException(MalformedEmailException::class);
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('not-an-email')
+            ->setUsername('spammer')
+            ->reportSpam();
+    }
+
+    public function test_it_will_throw_exception_when_report_spam_without_username()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('username is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->reportSpam();
     }
 }

--- a/tests/StopForumSpamTest.php
+++ b/tests/StopForumSpamTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Http;
 use nickurt\StopForumSpam\Events\IsSpamEmail;
 use nickurt\StopForumSpam\Events\IsSpamIp;
 use nickurt\StopForumSpam\Events\IsSpamUsername;
+use nickurt\StopForumSpam\Exception\MalformedEmailException;
+use nickurt\StopForumSpam\Exception\MalformedIPException;
 use nickurt\StopForumSpam\Exception\MalformedURLException;
 use nickurt\StopForumSpam\Facade as StopForumSpam;
 
@@ -180,5 +182,106 @@ class StopForumSpamTest extends TestCase
         $this->expectException(MalformedURLException::class);
 
         $this->stopForumSpam->setApiUrl('malformed_url');
+    }
+
+    public function test_it_can_add_to_database()
+    {
+        Http::fake(['https://www.stopforumspam.com/add.php' => Http::response('', 200)]);
+
+        $result = $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->addToDatabase();
+
+        $this->assertTrue($result);
+    }
+
+    public function test_it_can_add_to_database_with_evidence()
+    {
+        Http::fake(['https://www.stopforumspam.com/add.php' => Http::response('', 200)]);
+
+        $result = $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->setEvidence('Posted 50 identical spam messages.')
+            ->addToDatabase();
+
+        $this->assertTrue($result);
+    }
+
+    public function test_it_will_throw_exception_when_add_to_database_without_api_key()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('StopForumSpam API key is required.');
+
+        $this->stopForumSpam
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->addToDatabase();
+    }
+
+    public function test_it_will_throw_exception_when_add_to_database_without_ip()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('ip is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->addToDatabase();
+    }
+
+    public function test_it_will_throw_malformed_ip_exception_when_add_to_database_with_invalid_ip()
+    {
+        $this->expectException(MalformedIPException::class);
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('not-an-ip')
+            ->setEmail('spam@example.com')
+            ->setUsername('spammer')
+            ->addToDatabase();
+    }
+
+    public function test_it_will_throw_exception_when_add_to_database_without_email()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('email is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setUsername('spammer')
+            ->addToDatabase();
+    }
+
+    public function test_it_will_throw_malformed_email_exception_when_add_to_database_with_invalid_email()
+    {
+        $this->expectException(MalformedEmailException::class);
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('not-an-email')
+            ->setUsername('spammer')
+            ->addToDatabase();
+    }
+
+    public function test_it_will_throw_exception_when_add_to_database_without_username()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('username is required.');
+
+        $this->stopForumSpam
+            ->setApiKey('test-api-key')
+            ->setIp('191.186.18.61')
+            ->setEmail('spam@example.com')
+            ->addToDatabase();
     }
 }


### PR DESCRIPTION
This PR adds the ability to submit spam to the database. This is useful if spam is missed by SFS and needs to be submited. 

It does require an API key which is free from Stop Fourm Spam's website.

This is a quick PR, and edits are welcome. I need to do more testing as well, but should fix #29 